### PR TITLE
Fix client neural net build error

### DIFF
--- a/app/chess/ai-utils.ts
+++ b/app/chess/ai-utils.ts
@@ -4,7 +4,6 @@
  */
 
 import type { Board, Move, PieceColor, AIPersonality } from './types';
-import { selectMoveWithModel as clientSelectMove } from './utils/clientNeuralNet';
 
 // Timestamp tracking to avoid duplicated API calls
 let lastApiCallTimestamp = 0;
@@ -73,9 +72,10 @@ async function selectMoveClientSide(board: Board, legalMoves: Move[], turn: Piec
     // First try the neural network for higher AI levels
     if (aiLevel >= 6) {
       // Try to use the client-side neural network model
-      const move = await clientSelectMove(board, legalMoves, turn, aiLevel);
+      const { selectMoveWithModel } = await import("./utils/clientNeuralNet");
+      const move = await selectMoveWithModel(board, legalMoves, turn, aiLevel);
       if (move) {
-        console.log('Client-side neural network used for move selection');
+        console.log("Client-side neural network used for move selection");
         return move;
       }
     }

--- a/app/chess/utils/clientNeuralNet.ts
+++ b/app/chess/utils/clientNeuralNet.ts
@@ -3,9 +3,7 @@
  * This allows the model to run in the browser using ONNX Runtime Web
  */
 
-import { useEffect, useState } from 'react';
 import * as ort from 'onnxruntime-web';
-import type { Board, PieceColor, Move } from '../types';
 
 // Model URL from environment variables
 const PUBLIC_MODEL_URL = process.env.NEXT_PUBLIC_CHESS_MODEL_URL || '/models/chess-model.onnx';
@@ -227,50 +225,3 @@ export async function selectMoveWithModel(
   }
 }
 
-/**
- * Custom hook to use the neural network model in React components
- */
-export function useChessAI() {
-  const [modelReady, setModelReady] = useState(!!session);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(modelLoadError);
-  
-  useEffect(() => {
-    let mounted = true;
-    
-    async function loadModel() {
-      if (session || isModelLoading) return;
-      
-      setLoading(true);
-      try {
-        const loadedSession = await initializeModel();
-        if (mounted) {
-          setModelReady(!!loadedSession);
-          setError(modelLoadError);
-        }
-      } catch (err) {
-        if (mounted) {
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
-      } finally {
-        if (mounted) {
-          setLoading(false);
-        }
-      }
-    }
-    
-    loadModel();
-    
-    return () => {
-      mounted = false;
-    };
-  }, []);
-  
-  return {
-    selectMove: selectMoveWithModel,
-    evaluate: evaluatePositionWithModel,
-    modelReady,
-    loading,
-    error
-  };
-}

--- a/hooks/use-chess-ai.ts
+++ b/hooks/use-chess-ai.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { initializeModel, selectMoveWithModel, evaluatePositionWithModel } from "@/app/chess/utils/clientNeuralNet";
+
+export function useChessAI() {
+  const [modelReady, setModelReady] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadModel() {
+      if (typeof window === "undefined") return;
+
+      setLoading(true);
+      try {
+        const loadedSession = await initializeModel();
+        if (mounted) {
+          setModelReady(!!loadedSession);
+          setError(null);
+        }
+      } catch (err) {
+        if (mounted) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadModel();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return {
+    selectMove: selectMoveWithModel,
+    evaluate: evaluatePositionWithModel,
+    modelReady,
+    loading,
+    error,
+  };
+}


### PR DESCRIPTION
## Summary
- remove React hooks from client chess utils
- add `useChessAI` hook in a client file
- dynamically import client neural net utils to avoid server imports

## Testing
- `npm run build` *(fails: connect EHOSTUNREACH)*