### PR TITLE
Connect camera capture to voice assistant

### DIFF
--- a/app/demos/computer-vision-assistant/components/VoiceInterface.tsx
+++ b/app/demos/computer-vision-assistant/components/VoiceInterface.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 
 interface VoiceInterfaceProps {
-  onImageAnalysisRequest?: () => void;
+  onImageAnalysisRequest?: (query: string) => void;
   imageAnalysisResult?: any;
 }
 
@@ -107,7 +107,7 @@ export default function VoiceInterface({ onImageAnalysisRequest, imageAnalysisRe
     );
     
     if (isImageAnalysisRequest && onImageAnalysisRequest) {
-      onImageAnalysisRequest();
+      onImageAnalysisRequest(transcript);
       return;
     }
     


### PR DESCRIPTION
## Summary
- expose `analyzeNow` handle from `CameraCapture`
- replace `VideoComponent` with `CameraCapture` and wire its results to `VoiceInterface`
- allow `VoiceInterface` to send the voice transcript when requesting an image analysis
- play spoken response after capturing a frame and querying the API

## Testing
- `npm run lint` *(fails: EHOSTUNREACH)*