### PR TITLE
Add enhanced RAG LangChain demo

### DIFF
--- a/app/api/enhanced-rag-langchain/query/route.ts
+++ b/app/api/enhanced-rag-langchain/query/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ChatOpenAI, OpenAIEmbeddings } from '@langchain/openai';
+import { RetrievalQAChain } from 'langchain/chains';
+import { MemoryVectorStore } from 'langchain/vectorstores/memory';
+import { Document } from 'langchain/document';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { question } = await req.json();
+    if (!question || typeof question !== 'string') {
+      return NextResponse.json({ error: 'Invalid question' }, { status: 400 });
+    }
+
+    // Sample knowledge base
+    const docs = [
+      new Document({ pageContent: 'LangChain is a framework for building applications with language models.' }),
+      new Document({ pageContent: 'Retrieval-augmented generation (RAG) combines information retrieval with text generation.' }),
+      new Document({ pageContent: 'This demo uses an in-memory vector store with OpenAI embeddings.' })
+    ];
+
+    const embeddings = new OpenAIEmbeddings({ apiKey: process.env.OPENAI_API_KEY || '' });
+    const vectorStore = await MemoryVectorStore.fromDocuments(docs, embeddings);
+    const retriever = vectorStore.asRetriever();
+
+    const model = new ChatOpenAI({
+      openAIApiKey: process.env.OPENAI_API_KEY || '',
+      temperature: 0,
+      modelName: 'gpt-3.5-turbo'
+    });
+
+    const chain = RetrievalQAChain.fromLLM(model, retriever);
+    const response = await chain.call({ query: question });
+
+    return NextResponse.json({ answer: response.text });
+  } catch (err) {
+    console.error('RAG demo error:', err);
+    return NextResponse.json({ error: 'Failed to generate answer' }, { status: 500 });
+  }
+}

--- a/app/demos/enhanced-rag-langchain/components/EnhancedRAGDemo.tsx
+++ b/app/demos/enhanced-rag-langchain/components/EnhancedRAGDemo.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+
+export default function EnhancedRAGDemo() {
+  const [question, setQuestion] = useState("");
+  const [answer, setAnswer] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const askQuestion = async () => {
+    if (!question.trim()) return;
+    setLoading(true);
+    setAnswer(null);
+
+    try {
+      const res = await fetch("/api/enhanced-rag-langchain/query", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        setAnswer(data.answer || "No answer generated.");
+      } else {
+        setAnswer("Error retrieving answer.");
+      }
+    } catch (err) {
+      console.error(err);
+      setAnswer("Error communicating with API.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Enhanced RAG Demo</h1>
+      <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        Ask a question and see how LangChain retrieves relevant context before
+        answering.
+      </p>
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          className="flex-1 border rounded px-3 py-2 dark:bg-neutral-800"
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder="Enter your question"
+        />
+        <button
+          onClick={askQuestion}
+          disabled={loading}
+          className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+        >
+          {loading ? "Asking..." : "Ask"}
+        </button>
+      </div>
+      {answer && (
+        <div className="border rounded p-4 bg-neutral-50 dark:bg-neutral-800">
+          {answer}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/demos/enhanced-rag-langchain/page.tsx
+++ b/app/demos/enhanced-rag-langchain/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import ClientOnly from "@/app/components/ClientOnly";
+
+const EnhancedRAGDemo = dynamic(() => import("./components/EnhancedRAGDemo"), {
+  ssr: false,
+});
+
+export default function EnhancedRAGPage() {
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <ClientOnly>
+        <EnhancedRAGDemo />
+      </ClientOnly>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Enhanced RAG LangChain demo page and component
- create API route using LangChain to answer questions from in-memory docs

## Testing
- `npm run lint` *(fails: request to https://registry.npmjs.org/next failed)*