### PR TITLE
Add generative AI demo

### DIFF
--- a/app/api/generative-ai/route.ts
+++ b/app/api/generative-ai/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { OpenAI } from 'openai'
+
+export const runtime = 'edge'
+export const maxDuration = 15
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY || ''
+})
+
+export async function POST(req: NextRequest) {
+  try {
+    const { prompt, type } = await req.json()
+
+    if (!prompt || typeof prompt !== 'string') {
+      return NextResponse.json({ error: 'Prompt is required' }, { status: 400 })
+    }
+
+    if (type !== 'text' && type !== 'image') {
+      return NextResponse.json({ error: 'Invalid type' }, { status: 400 })
+    }
+
+    if (type === 'text') {
+      const completion = await openai.chat.completions.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: prompt }]
+      })
+      const text = completion.choices[0]?.message?.content || ''
+      return NextResponse.json({ text })
+    }
+
+    const image = await openai.images.generate({
+      model: 'dall-e-3',
+      prompt,
+      n: 1,
+      size: '1024x1024'
+    })
+
+    const imageUrl = image.data[0]?.url
+    return NextResponse.json({ imageUrl })
+  } catch (error) {
+    console.error('Error generating content:', error)
+    return NextResponse.json(
+      { error: 'Failed to generate content' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/demos/generative-ai/README.md
+++ b/app/demos/generative-ai/README.md
@@ -1,0 +1,10 @@
+# Generative AI Demo
+
+This demo lets you create text or images from a single prompt using OpenAI models.
+
+## Usage
+1. Select whether you want text or an image.
+2. Enter a prompt describing what you want.
+3. Click **Generate** to see the result.
+
+The server route `/api/generative-ai` handles the request using GPT-4 for text and DALL·E for images.

--- a/app/demos/generative-ai/metadata.ts
+++ b/app/demos/generative-ai/metadata.ts
@@ -1,0 +1,10 @@
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Generative AI Demo | Text & Image Creation',
+  description: 'Generate creative text and images using OpenAI models.',
+  openGraph: {
+    title: 'Generative AI Demo',
+    description: 'Generate creative text and images using OpenAI models.'
+  }
+}

--- a/app/demos/generative-ai/page.tsx
+++ b/app/demos/generative-ai/page.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useState } from 'react'
+import ClientOnly from '@/app/components/ClientOnly'
+
+export default function GenerativeAIDemo() {
+  const [prompt, setPrompt] = useState('')
+  const [type, setType] = useState<'text' | 'image'>('text')
+  const [result, setResult] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleGenerate = async () => {
+    if (!prompt.trim()) return
+    setLoading(true)
+    setResult(null)
+
+    try {
+      const res = await fetch('/api/generative-ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt, type })
+      })
+      const data = await res.json()
+      if (data.error) {
+        setResult(`Error: ${data.error}`)
+      } else if (type === 'text') {
+        setResult(data.text)
+      } else {
+        setResult(data.imageUrl)
+      }
+    } catch (err) {
+      setResult('Failed to generate.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-2">Generative AI Demo</h1>
+      <p className="text-gray-700 dark:text-gray-300 mb-4">
+        Enter a prompt to generate text or images using AI.
+      </p>
+      <div className="flex items-center mb-4 space-x-2">
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value as 'text' | 'image')}
+          className="border rounded px-2 py-1"
+        >
+          <option value="text">Text</option>
+          <option value="image">Image</option>
+        </select>
+        <input
+          type="text"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Enter your prompt..."
+          className="flex-1 border rounded px-2 py-1"
+        />
+        <button
+          onClick={handleGenerate}
+          disabled={loading}
+          className="px-4 py-1 bg-blue-600 text-white rounded disabled:opacity-50"
+        >
+          {loading ? 'Generating...' : 'Generate'}
+        </button>
+      </div>
+      {result && type === 'text' && (
+        <div className="whitespace-pre-wrap p-4 border rounded bg-gray-100 dark:bg-gray-800">
+          {result}
+        </div>
+      )}
+      {result && type === 'image' && typeof result === 'string' && (
+        <div className="mt-4">
+          {/* ClientOnly wrapper ensures image is only rendered client-side */}
+          <ClientOnly>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={result} alt="Generated" className="max-w-full h-auto" />
+          </ClientOnly>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add API route for generating text or images via OpenAI
- add Generative AI demo page with simple UI
- document the demo
- include demo metadata

## Testing
- `npm run lint` *(fails: connect EHOSTUNREACH)*
- `npm run build` *(fails: connect EHOSTUNREACH)*