### PR TITLE
Enhance AI Sales Agent demo

### DIFF
--- a/app/demos/ai-sales-agent/README.md
+++ b/app/demos/ai-sales-agent/README.md
@@ -5,12 +5,16 @@ This demo showcases a simple AI Sales Agent chat interface built with React and 
 ## Features
 - Basic chat interface with user and agent messages
 - Predefined agent responses for demo purposes
+- Messages persist locally between visits
+- Typing indicator shows when the agent is preparing a reply
+- Clear Chat button to reset the conversation
 - Responsive design using Tailwind CSS
 
 ## Usage
 1. Navigate to `/demos/ai-sales-agent` in the portfolio app.
 2. Type a message and press **Enter** or click the send button.
 3. The agent will reply with a short sales-oriented message.
+4. Use the **Clear Chat** button to start a new conversation at any time.
 
 ---
 

--- a/app/demos/ai-sales-agent/components/SalesAgent.tsx
+++ b/app/demos/ai-sales-agent/components/SalesAgent.tsx
@@ -1,13 +1,9 @@
 'use client'
 
-import React, { useState, useRef, useEffect } from 'react'
-import { Send } from 'lucide-react'
+import React, { useRef, useEffect, useState } from 'react'
+import { Send, Trash2 } from 'lucide-react'
+import { useChatHistory, ChatMessage } from '@/hooks/use-chat-history'
 
-interface Message {
-  id: number
-  role: 'user' | 'agent'
-  text: string
-}
 
 const agentReplies = [
   "Hi there! I'm here to help you find the best solution for your business.",
@@ -15,15 +11,16 @@ const agentReplies = [
   "Great! I'll prepare a proposal and send it to your email shortly."
 ]
 
+const initialMessage: ChatMessage = {
+  id: 0,
+  role: 'agent',
+  text: 'Welcome to the AI Sales Agent demo. How can I assist you today?'
+}
+
 export default function SalesAgent() {
-  const [messages, setMessages] = useState<Message[]>([
-    {
-      id: 0,
-      role: 'agent',
-      text: 'Welcome to the AI Sales Agent demo. How can I assist you today?'
-    }
-  ])
+  const { messages, setMessages, clearMessages } = useChatHistory([initialMessage])
   const [input, setInput] = useState('')
+  const [isTyping, setIsTyping] = useState(false)
   const replyIndex = useRef(0)
   const endRef = useRef<HTMLDivElement>(null)
 
@@ -34,7 +31,7 @@ export default function SalesAgent() {
   const sendMessage = () => {
     if (!input.trim()) return
 
-    const userMsg: Message = {
+    const userMsg: ChatMessage = {
       id: Date.now(),
       role: 'user',
       text: input.trim()
@@ -44,13 +41,15 @@ export default function SalesAgent() {
 
     const reply = agentReplies[replyIndex.current % agentReplies.length]
     replyIndex.current += 1
-    const agentMsg: Message = {
-      id: Date.now() + 1,
-      role: 'agent',
-      text: reply
-    }
+    setIsTyping(true)
     setTimeout(() => {
+      const agentMsg: ChatMessage = {
+        id: Date.now() + 1,
+        role: 'agent',
+        text: reply
+      }
       setMessages(prev => [...prev, agentMsg])
+      setIsTyping(false)
     }, 500)
   }
 
@@ -63,12 +62,25 @@ export default function SalesAgent() {
 
   return (
     <div className="max-w-md mx-auto bg-white dark:bg-gray-800 p-4 rounded-lg shadow-md">
+      <div className="flex justify-end mb-2">
+        <button
+          onClick={clearMessages}
+          className="flex items-center text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          <Trash2 className="w-4 h-4 mr-1" /> Clear Chat
+        </button>
+      </div>
       <div className="h-80 overflow-y-auto space-y-4 mb-4" data-testid="messages">
         {messages.map(m => (
           <div key={m.id} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
             <div className={`rounded-lg px-3 py-2 text-sm ${m.role === 'user' ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'}`}>{m.text}</div>
           </div>
         ))}
+        {isTyping && (
+          <div className="flex justify-start">
+            <div className="rounded-lg px-3 py-2 text-sm bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100">Agent is typing...</div>
+          </div>
+        )}
         <div ref={endRef} />
       </div>
       <div className="flex">

--- a/hooks/use-chat-history.ts
+++ b/hooks/use-chat-history.ts
@@ -1,0 +1,39 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+export interface ChatMessage {
+  id: number
+  role: "user" | "agent"
+  text: string
+}
+
+const STORAGE_KEY = "salesAgentMessages"
+
+export function useChatHistory(initial: ChatMessage[]) {
+  const [messages, setMessages] = useState<ChatMessage[]>(() => {
+    if (typeof window === "undefined") return initial
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        return JSON.parse(stored) as ChatMessage[]
+      }
+    } catch {
+      // ignore JSON errors
+    }
+    return initial
+  })
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(messages))
+    } catch {
+      // ignore write errors
+    }
+  }, [messages])
+
+  const clearMessages = () => setMessages(initial)
+
+  return { messages, setMessages, clearMessages }
+}


### PR DESCRIPTION
## Summary
- add `useChatHistory` hook for local chat persistence
- improve `SalesAgent` with typing indicator and clear chat button
- persist messages across sessions
- document new demo features

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@supabase/supabase-js'...)*
- `npm run lint` *(fails: command timed out or produced no output)*