### PR TITLE
Enhance generative AI demo

### DIFF
--- a/app/api/generative-ai/route.ts
+++ b/app/api/generative-ai/route.ts
@@ -10,7 +10,7 @@ const openai = new OpenAI({
 
 export async function POST(req: NextRequest) {
   try {
-    const { prompt, type } = await req.json()
+    const { prompt, type, temperature, size } = await req.json()
 
     if (!prompt || typeof prompt !== 'string') {
       return NextResponse.json({ error: 'Prompt is required' }, { status: 400 })
@@ -20,10 +20,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid type' }, { status: 400 })
     }
 
+    const temp =
+      typeof temperature === 'number' && !Number.isNaN(temperature)
+        ? temperature
+        : 1
+
+    const imgSize = typeof size === 'string' ? size : '1024x1024'
+
     if (type === 'text') {
       const completion = await openai.chat.completions.create({
         model: 'gpt-4',
-        messages: [{ role: 'user', content: prompt }]
+        messages: [{ role: 'user', content: prompt }],
+        temperature: temp
       })
       const text = completion.choices[0]?.message?.content || ''
       return NextResponse.json({ text })
@@ -33,7 +41,7 @@ export async function POST(req: NextRequest) {
       model: 'dall-e-3',
       prompt,
       n: 1,
-      size: '1024x1024'
+      size: imgSize
     })
 
     const imageUrl = image.data[0]?.url

--- a/app/demos/generative-ai/README.md
+++ b/app/demos/generative-ai/README.md
@@ -1,10 +1,11 @@
 # Generative AI Demo
 
-This demo lets you create text or images from a single prompt using OpenAI models.
+This demo lets you create text or images from a single prompt using OpenAI models. You can tweak the text generation temperature or pick an output image size.
 
 ## Usage
 1. Select whether you want text or an image.
 2. Enter a prompt describing what you want.
-3. Click **Generate** to see the result.
+3. Adjust the temperature for text or choose an image size.
+4. Click **Generate** to see the result.
 
 The server route `/api/generative-ai` handles the request using GPT-4 for text and DALL·E for images.

--- a/app/demos/generative-ai/page.tsx
+++ b/app/demos/generative-ai/page.tsx
@@ -6,6 +6,8 @@ import ClientOnly from '@/app/components/ClientOnly'
 export default function GenerativeAIDemo() {
   const [prompt, setPrompt] = useState('')
   const [type, setType] = useState<'text' | 'image'>('text')
+  const [temperature, setTemperature] = useState(1)
+  const [size, setSize] = useState('1024x1024')
   const [result, setResult] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
@@ -18,7 +20,7 @@ export default function GenerativeAIDemo() {
       const res = await fetch('/api/generative-ai', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt, type })
+        body: JSON.stringify({ prompt, type, temperature, size })
       })
       const data = await res.json()
       if (data.error) {
@@ -65,6 +67,40 @@ export default function GenerativeAIDemo() {
           {loading ? 'Generating...' : 'Generate'}
         </button>
       </div>
+      {type === 'text' && (
+        <div className="mb-4 flex items-center space-x-2">
+          <label htmlFor="temperature" className="text-sm whitespace-nowrap">
+            Temperature:
+          </label>
+          <input
+            id="temperature"
+            type="number"
+            min={0}
+            max={1}
+            step={0.1}
+            value={temperature}
+            onChange={(e) => setTemperature(parseFloat(e.target.value))}
+            className="border rounded px-2 py-1 w-24"
+          />
+        </div>
+      )}
+      {type === 'image' && (
+        <div className="mb-4 flex items-center space-x-2">
+          <label htmlFor="size" className="text-sm whitespace-nowrap">
+            Size:
+          </label>
+          <select
+            id="size"
+            value={size}
+            onChange={(e) => setSize(e.target.value)}
+            className="border rounded px-2 py-1"
+          >
+            <option value="1024x1024">1024x1024</option>
+            <option value="1792x1024">1792x1024</option>
+            <option value="1024x1792">1024x1792</option>
+          </select>
+        </div>
+      )}
       {result && type === 'text' && (
         <div className="whitespace-pre-wrap p-4 border rounded bg-gray-100 dark:bg-gray-800">
           {result}


### PR DESCRIPTION
## Summary
- allow selecting temperature and image size in Generative AI demo
- support temperature/size in API route
- update demo documentation

## Testing
- `npm run lint` *(fails: connect EHOSTUNREACH)*
- `node test-contact-api.js` *(fails: Cannot find module 'node-fetch')*
- `node test-contact-form-browser.js` *(fails: ERR_INVALID_URL)*
- `node test-email.js` *(fails: Cannot find module 'dotenv')*
- `node test-email-options.js` *(fails: Cannot find module 'dotenv')*