### PR TITLE
Add navigation between demo pages

### DIFF
--- a/app/components/DemoNavigation.tsx
+++ b/app/components/DemoNavigation.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { demos } from "@/lib/demosData";
+
+export default function DemoNavigation() {
+  const pathname = usePathname();
+  const slug = pathname.split("/").pop() || "";
+  const index = demos.findIndex((d) => d.slug === slug);
+  if (index === -1) return null;
+
+  const prevDemo = index > 0 ? demos[index - 1] : null;
+  const nextDemo = index < demos.length - 1 ? demos[index + 1] : null;
+
+  return (
+    <nav className="mt-8 flex justify-between items-center border-t pt-4">
+      {prevDemo ? (
+        <Link href={`/demos/${prevDemo.slug}`} className="text-blue-500 hover:underline">
+          ← {prevDemo.title}
+        </Link>
+      ) : <span />}
+      <Link href="/demos" className="text-blue-500 hover:underline">
+        Back to All Demos
+      </Link>
+      {nextDemo ? (
+        <Link href={`/demos/${nextDemo.slug}`} className="text-blue-500 hover:underline">
+          {nextDemo.title} →
+        </Link>
+      ) : <span />}
+    </nav>
+  );
+}

--- a/app/demos/[demo]/page.tsx
+++ b/app/demos/[demo]/page.tsx
@@ -1,62 +1,10 @@
 "use client"
 
 import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { notFound } from "next/navigation"
+import { useRouter, notFound } from "next/navigation"
 import { X } from "lucide-react"
-
-const demos = [
-  {
-    slug: "financial-assistant",
-    title: "Financial Market Assistant",
-    description: "Get real-time financial analysis, market insights, and investment advice.",
-  },
-  {
-    slug: "computer-vision-assistant",
-    title: "Computer Vision Assistant",
-    description: "Analyze and interpret visual data with our AI-powered vision system.",
-  },
-  {
-    slug: "chess-ai-magnus",
-    title: "Advanced Chess AI Engine",
-    description: "Play against a neural network chess engine trained with deep reinforcement learning techniques.",
-  },
-  {
-    slug: "generative-ai",
-    title: "Generative AI (Text & Image Creation)",
-    description: "Create unique text and images using cutting-edge generative AI models.",
-  },
-  {
-    slug: "knowledge-graph",
-    title: "AI-Powered Knowledge Graph",
-    description: "Explore complex relationships in data with our intelligent knowledge graph.",
-  },
-  {
-    slug: "ai-sales-agent",
-    title: "AI Sales Agent (CrewAI-Powered)",
-    description: "Experience an AI-driven sales conversation powered by CrewAI.",
-  },
-  {
-    slug: "interactive-agents",
-    title: "Interactive AI Agents (CrewAI Task Collaboration)",
-    description: "See multiple AI agents collaborate on complex tasks using CrewAI.",
-  },
-  {
-    slug: "youtube-summarizer",
-    title: "YouTube Summarizer & Insights",
-    description: "Get quick summaries and key insights from YouTube videos.",
-  },
-  {
-    slug: "data-analyst-assistant",
-    title: "AI Data Analyst Assistant",
-    description: "Let AI help you analyze and interpret complex datasets.",
-  },
-  {
-    slug: "enhanced-rag-langchain",
-    title: "Enhanced RAG (LangChain)",
-    description: "Experience advanced retrieval-augmented generation using LangChain.",
-  },
-]
+import { demos } from "@/lib/demosData"
+import DemoNavigation from "@/app/components/DemoNavigation"
 
 export default function DemoPage({ params }: { params: { demo: string } }) {
   const router = useRouter()
@@ -65,10 +13,6 @@ export default function DemoPage({ params }: { params: { demo: string } }) {
   if (!demo) {
     notFound()
   }
-
-  const currentIndex = demos.findIndex((d) => d.slug === params.demo)
-  const prevDemo = currentIndex > 0 ? demos[currentIndex - 1] : null
-  const nextDemo = currentIndex < demos.length - 1 ? demos[currentIndex + 1] : null
 
   return (
     <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12 relative">
@@ -81,10 +25,6 @@ export default function DemoPage({ params }: { params: { demo: string } }) {
         <X className="h-6 w-6" />
       </button>
 
-      <Link href="/demos" className="text-blue-500 hover:underline mb-4 inline-block">
-        ← Back to All Demos
-      </Link>
-
       <h1 className="text-3xl font-bold mb-4">{demo.title}</h1>
       <p className="text-gray-700 dark:text-gray-300 mb-8">{demo.description}</p>
 
@@ -93,18 +33,7 @@ export default function DemoPage({ params }: { params: { demo: string } }) {
         <p>Placeholder for the {demo.title} interface. Coming soon for full functionality...</p>
       </div>
 
-      <div className="flex justify-between">
-        {prevDemo && (
-          <Link href={`/demos/${prevDemo.slug}`} className="text-blue-500 hover:underline">
-            ← {prevDemo.title}
-          </Link>
-        )}
-        {nextDemo && (
-          <Link href={`/demos/${nextDemo.slug}`} className="text-blue-500 hover:underline">
-            {nextDemo.title} →
-          </Link>
-        )}
-      </div>
+      <DemoNavigation />
     </main>
   )
 }

--- a/app/demos/ai-sales-agent/page.tsx
+++ b/app/demos/ai-sales-agent/page.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic'
 import ClientOnly from '@/app/components/ClientOnly'
+import DemoNavigation from '@/app/components/DemoNavigation'
 
 const SalesAgent = dynamic(() => import('./components/SalesAgent'), { ssr: false })
 
@@ -11,6 +12,7 @@ export default function AiSalesAgentPage() {
       <ClientOnly>
         <SalesAgent />
       </ClientOnly>
+      <DemoNavigation />
     </div>
   )
 }

--- a/app/demos/chess-ai-magnus/page.tsx
+++ b/app/demos/chess-ai-magnus/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import ClientSideAI, { useAIModelStatus } from '@/app/chess/components/ClientSideAI';
+import DemoNavigation from '@/app/components/DemoNavigation';
 import {
     Cpu, Brain, Code, ChevronRight, Star, Trophy, Zap,
     Github, Info, RotateCcw, Undo, AlertCircle, Layers,
@@ -1329,6 +1330,7 @@ const formatMetricName = (name: string) => {
     );
 
     return (
+        <>
         <main className="min-h-screen p-2 sm:p-4 md:p-6 bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100" ref={mainContainerRef} data-component-name="ChessAIDemo">
             {/* Preload client-side neural network model */}
             <ClientSideAI />
@@ -1380,6 +1382,8 @@ const formatMetricName = (name: string) => {
                 </div>
             </div>
         </main>
+        <DemoNavigation />
+        </>
     );
 }
 

--- a/app/demos/computer-vision-assistant/page.tsx
+++ b/app/demos/computer-vision-assistant/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import type { CameraCaptureHandle, AnalysisResult } from "./components/CameraCapture";
 import dynamic from "next/dynamic";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import DemoNavigation from "@/app/components/DemoNavigation";
 import "./computerVision.css";
 
 // Define message interface
@@ -142,6 +143,7 @@ export default function ComputerVisionAssistant() {
           </div>
         )}
       </main>
+      <DemoNavigation />
     </div>
   );
 }

--- a/app/demos/data-analyst-assistant/page.tsx
+++ b/app/demos/data-analyst-assistant/page.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
+import DemoNavigation from '@/app/components/DemoNavigation';
 
 // Import ClientOnly to prevent SSR issues
 import ClientOnly from '@/app/components/ClientOnly';
@@ -22,6 +23,7 @@ export default function DataAnalystAssistantPage() {
       <ClientOnly>
         <DataAnalystAssistant />
       </ClientOnly>
+      <DemoNavigation />
     </div>
   );
 }

--- a/app/demos/enhanced-rag-langchain/page.tsx
+++ b/app/demos/enhanced-rag-langchain/page.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import ClientOnly from "@/app/components/ClientOnly";
+import DemoNavigation from "@/app/components/DemoNavigation";
 
 const EnhancedRAGDemo = dynamic(() => import("./components/EnhancedRAGDemo"), {
   ssr: false,
@@ -13,6 +14,7 @@ export default function EnhancedRAGPage() {
       <ClientOnly>
         <EnhancedRAGDemo />
       </ClientOnly>
+      <DemoNavigation />
     </div>
   );
 }

--- a/app/demos/financial-assistant/page.tsx
+++ b/app/demos/financial-assistant/page.tsx
@@ -13,6 +13,7 @@ import dynamic from 'next/dynamic';
 import UserPreferences, { UserPreferencesData } from './components/UserPreferences';
 import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
+import DemoNavigation from '@/app/components/DemoNavigation'
 
 // Minimal markdown to HTML converter for chat messages
 function simpleMarkdownToHtml(text: string): string {
@@ -1366,6 +1367,7 @@ export default function FinancialAssistantPage() {
           </div>
         </Dialog>
       </Transition>
+      <DemoNavigation />
     </>
   );
-} 
+}

--- a/app/demos/generative-ai/page.tsx
+++ b/app/demos/generative-ai/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import ClientOnly from '@/app/components/ClientOnly'
+import DemoNavigation from '@/app/components/DemoNavigation'
 
 export default function GenerativeAIDemo() {
   const [prompt, setPrompt] = useState('')
@@ -115,6 +116,7 @@ export default function GenerativeAIDemo() {
           </ClientOnly>
         </div>
       )}
+      <DemoNavigation />
     </div>
   )
 }

--- a/app/demos/interactive-agents/page.tsx
+++ b/app/demos/interactive-agents/page.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic'
 import ClientOnly from '@/app/components/ClientOnly'
+import DemoNavigation from '@/app/components/DemoNavigation'
 
 const InteractiveAgentsDemo = dynamic(() => import('./InteractiveAgentsDemo'), { ssr: false })
 
@@ -11,6 +12,7 @@ export default function InteractiveAgentsPage() {
       <ClientOnly>
         <InteractiveAgentsDemo />
       </ClientOnly>
+      <DemoNavigation />
     </div>
   )
 }

--- a/app/demos/youtube-summarizer/page.tsx
+++ b/app/demos/youtube-summarizer/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import DemoNavigation from "@/app/components/DemoNavigation";
 
 export default function YouTubeSummarizerPage() {
   const [videoUrl, setVideoUrl] = useState("");
@@ -57,6 +58,7 @@ export default function YouTubeSummarizerPage() {
           {summary}
         </pre>
       )}
+      <DemoNavigation />
     </div>
   );
 }

--- a/lib/demosData.ts
+++ b/lib/demosData.ts
@@ -1,0 +1,63 @@
+export interface DemoInfo {
+  slug: string;
+  title: string;
+  description: string;
+}
+
+export const demos: DemoInfo[] = [
+  {
+    slug: "financial-assistant",
+    title: "Financial Market Assistant",
+    description:
+      "Get real-time financial analysis, market insights, and investment advice.",
+  },
+  {
+    slug: "computer-vision-assistant",
+    title: "Computer Vision Assistant",
+    description:
+      "Analyze and interpret visual data with our AI-powered vision system.",
+  },
+  {
+    slug: "chess-ai-magnus",
+    title: "Advanced Chess AI Engine",
+    description:
+      "Play against a neural network chess engine trained with deep reinforcement learning techniques.",
+  },
+  {
+    slug: "generative-ai",
+    title: "Generative AI (Text & Image Creation)",
+    description:
+      "Create unique text and images using cutting-edge generative AI models.",
+  },
+  {
+    slug: "knowledge-graph",
+    title: "AI-Powered Knowledge Graph",
+    description:
+      "Explore complex relationships in data with our intelligent knowledge graph.",
+  },
+  {
+    slug: "ai-sales-agent",
+    title: "AI Sales Agent (CrewAI-Powered)",
+    description: "Experience an AI-driven sales conversation powered by CrewAI.",
+  },
+  {
+    slug: "interactive-agents",
+    title: "Interactive AI Agents (CrewAI Task Collaboration)",
+    description: "See multiple AI agents collaborate on complex tasks using CrewAI.",
+  },
+  {
+    slug: "youtube-summarizer",
+    title: "YouTube Summarizer & Insights",
+    description: "Get quick summaries and key insights from YouTube videos.",
+  },
+  {
+    slug: "data-analyst-assistant",
+    title: "AI Data Analyst Assistant",
+    description: "Let AI help you analyze and interpret complex datasets.",
+  },
+  {
+    slug: "enhanced-rag-langchain",
+    title: "Enhanced RAG (LangChain)",
+    description: "Experience advanced retrieval-augmented generation using LangChain.",
+  },
+];


### PR DESCRIPTION
## Summary
- centralize demo metadata in `lib/demosData.ts`
- add `DemoNavigation` component for prev/next/back links
- integrate demo navigation into all demo pages
- update generic demo page to consume shared demo data

## Testing
- `npm run lint` *(fails: connect EHOSTUNREACH)*